### PR TITLE
support named copies of the plugin

### DIFF
--- a/php_apc_
+++ b/php_apc_
@@ -47,13 +47,14 @@ if ( defined $ARGV[0] and $ARGV[0] eq "autoconf" )
 if ( defined $ARGV[0] and $ARGV[0] eq "config" )
 {
 
-$0 =~ /php_apc_(.+)*/;
-my $plugin = $1;
+$0 =~ /php_apc([^_]+)?_(.+)*/;
+my $custom_name = $1;
+my $plugin = $2;
 
 ## PHP APC Cache Usage
 if($plugin eq 'usage') {
-print('multigraph php_apc_usage
-graph_title Cache Usage
+print("multigraph php_apc$custom_name\_usage
+graph_title Cache Usage $custom_name
 graph_args --base 1024 -l 0
 graph_vlabel Bytes
 graph_category php-apc
@@ -65,13 +66,13 @@ fragmented.label Fragmented Memory
 fragmented.draw AREASTACK
 free.label Available Memory
 free.draw AREASTACK
-');
+");
 }
 
 ## PHP APC Cache Usage
 if($plugin eq 'mem_size') {
-print('multigraph php_apc_mem_size
-graph_title Used Memory
+print("multigraph php_apc$custom_name\_mem_size
+graph_title Used Memory $custom_name
 graph_args --base 1024 -l 0
 graph_vlabel Bytes
 graph_category php-apc
@@ -82,13 +83,13 @@ user_size.label User Cache
 user_size.draw AREASTACK
 free.label Available Memory
 free.draw AREASTACK
-');
+");
 }
 
 ## PHP APC Hit / Miss by percentage
 elsif($plugin eq 'hit_miss') {
-print('multigraph php_apc_hit_miss
-graph_title Optcode Cache Hits / Misses
+print("multigraph php_apc$custom_name\_hit_miss
+graph_title Optcode Cache Hits / Misses $custom_name
 graph_args --base 1000 --lower-limit 0 --upper-limit 100 --rigid
 graph_vlabel Percent
 graph_category php-apc
@@ -100,13 +101,13 @@ misses.label Misses
 misses.draw STACK
 misses.min 0
 misses.warning 50
-');
+");
 }
 
 ## PHP APC Purge rate (# Entries / Inserts)
 elsif($plugin eq 'purge') {
-print('multigraph php_apc_purge
-graph_title Purge rate
+print("multigraph php_apc$custom_name\_purge
+graph_title Purge rate $custom_name
 graph_args --base 1000 --lower-limit 0 --upper-limit 100 --rigid
 graph_vlabel Percent
 graph_category php-apc
@@ -118,13 +119,13 @@ user_purge_rate.label User Cache
 user_purge_rate.draw LINE2
 user_purge_rate.min 0
 user_purge_rate.warning 10
-');
+");
 }
 
 ## PHP APC Fragmentation
 elsif($plugin eq 'fragmentation') {
-print('multigraph php_apc_fragmentation
-graph_title Fragmentation
+print("multigraph php_apc$custom_name\_fragmentation
+graph_title Fragmentation $custom_name
 graph_args --base 1000 --upper-limit 100
 graph_vlabel Percent
 graph_category php-apc
@@ -132,26 +133,26 @@ fragment_percentage.label Fragmentation Percent
 fragment_percentage.draw LINE2
 fragment_percentage.min 0
 fragment_percentage.warning 10
-');
+");
 }
 
 ## PHP APC Number of files in cache
 elsif($plugin eq 'files') {
-print('multigraph php_apc_files
-graph_title Files in Optcode Cache
+print("multigraph php_apc$custom_name\_files
+graph_title Files in Optcode Cache $custom_name
 graph_args -l 0
 graph_vlabel Number of Files
 graph_category php-apc
 entries.label Number of files
 entries.draw LINE2
 entries.min 0
-');
+");
 }
 
 ## PHP APC Rates
 elsif($plugin eq 'rates') {
-print('multigraph php_apc_rates
-graph_title Optcode Hit, Miss and Insert Rates
+print("multigraph php_apc$custom_name\_rates
+graph_title Optcode Hit, Miss and Insert Rates $custom_name
 graph_args --base 1000
 graph_vlabel Cache Requests / Second
 graph_category php-apc
@@ -167,13 +168,13 @@ miss_rate.min 0
 insert_rate.label Insert rate
 insert_rate.draw LINE2
 insert_rate.min 0
-');
+");
 }
 
 ## PHP APC User Cache Hit / Miss by percentage
 elsif($plugin eq 'user_hit_miss') {
-print('multigraph php_apc_user_hit_miss
-graph_title User Cache Hits / Misses
+print("multigraph php_apc$custom_name\_user_hit_miss
+graph_title User Cache Hits / Misses $custom_name
 graph_args --base 1000 --lower-limit 0 --upper-limit 100 --rigid
 graph_vlabel Percent
 graph_category php-apc
@@ -185,26 +186,26 @@ user_misses.label Misses
 user_misses.draw STACK
 user_misses.min 0
 user_misses.warning 50
-');
+");
 }
 
 ## PHP APC User Cache Number of entries in cache
 elsif($plugin eq 'user_entries') {
-print('multigraph php_apc_user_entries
-graph_title User Entries in Cache
+print("multigraph php_apc$custom_name\_user_entries
+graph_title User Entries in Cache $custom_name
 graph_args -l 0
 graph_vlabel Number of Entries
 graph_category php-apc
 user_entries.label Number of entries
 user_entries.draw LINE2
 user_entries.min 0
-');
+");
 }
 
 ## PHP APC User Cache Rates
 elsif($plugin eq 'user_rates') {
-print('multigraph php_apc_user_rates
-graph_title User Cache Hit, Miss and Insert Rates
+print("multigraph php_apc$custom_name\_user_rates
+graph_title User Cache Hit, Miss and Insert Rates $custom_name
 graph_args --base 1000
 graph_vlabel Cache Requests / Second
 graph_category php-apc
@@ -220,7 +221,7 @@ user_miss_rate.min 0
 user_insert_rate.label Insert rate
 user_insert_rate.draw LINE2
 user_insert_rate.min 0
-');
+");
 }
 
 


### PR DESCRIPTION
When you want to monitor more than one instance of PHP on a single machine, it'll be useful to have the ability of run multiple named copies of the plug in.

Use cases:
- Monitoring PHP-FPM and mod_php on the same machine.
- Monitoring several PHP versions on the same machine
